### PR TITLE
Removed preprocessor conditions for configuring latest SMB dialects

### DIFF
--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -197,14 +197,6 @@ namespace SMBLibrary.Client
             request.Dialects.Add(SMB2Dialect.SMB202);
             request.Dialects.Add(SMB2Dialect.SMB210);
             request.Dialects.Add(SMB2Dialect.SMB300);
-#if SMB302_CLIENT
-            request.Dialects.Add(SMB2Dialect.SMB302);
-#endif
-#if SMB311_CLIENT
-            request.Dialects.Add(SMB2Dialect.SMB311);
-            request.NegotiateContextList = GetNegotiateContextList();
-            m_preauthIntegrityHashValue = new byte[64];
-#endif
             await TrySendCommandAsync(request, cancellationToken);
             var command = WaitForCommand(request.MessageID);
 


### PR DESCRIPTION
part of https://github.com/Dualog/DualogDrive.Client/issues/920